### PR TITLE
Initial implementation to handle uninstall of observability operator.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,6 +399,7 @@ cluster/cleanup/crds:
 	@-oc delete crd grafanadashboards.integreatly.org
 	@-oc delete crd grafanadatasources.integreatly.org
 	@-oc delete crd grafanas.integreatly.org
+	@-oc delete crd observabilities.observability.redhat.com
 	@-oc delete crd rhmis.integreatly.org
 	@-oc delete crd webapps.integreatly.org
 	@-oc delete crd rhmiconfigs.integreatly.org

--- a/apis/v1alpha1/rhmi_types.go
+++ b/apis/v1alpha1/rhmi_types.go
@@ -57,6 +57,7 @@ var (
 	SolutionExplorerStage        StageName = "solution-explorer"
 	UninstallProductsStage       StageName = "uninstall - products"
 	UninstallMonitoringStage     StageName = "uninstall - monitoring"
+	UninstallObservabilityStage  StageName = "uninstall - observability"
 	UninstallCloudResourcesStage StageName = "uninstall - cloud-resources"
 
 	ProductAMQStreams          ProductName = "amqstreams"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -194,6 +194,16 @@ rules:
   - get
   - update
 - apiGroups:
+  - observability.redhat.com
+  resources:
+  - observabilities
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
   - operator.marin3r.3scale.net
   resources:
   - discoveryservices

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -202,6 +202,9 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // Permission to remove crd for the marin3r operator upgrade from 0.5.1 to 0.7.0
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=delete;get;list
 
+// Observability
+// +kubebuilder:rbac:groups=observability.redhat.com,resources=observabilities,verbs=get;list;create;update;delete
+
 // Role permissions
 
 // +kubebuilder:rbac:groups="",resources=pods;events;configmaps;secrets,verbs=list;get;watch;create;update;patch,namespace=integreatly-operator

--- a/controllers/rhmi/types.go
+++ b/controllers/rhmi/types.go
@@ -76,6 +76,12 @@ var (
 				},
 			},
 			{
+				Name: integreatlyv1alpha1.UninstallObservabilityStage,
+				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
+					integreatlyv1alpha1.ProductObservability: {Name: integreatlyv1alpha1.ProductObservability},
+				},
+			},
+			{
 				Name: integreatlyv1alpha1.UninstallMonitoringStage,
 				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
 					integreatlyv1alpha1.ProductMonitoring:     {Name: integreatlyv1alpha1.ProductMonitoring},
@@ -145,6 +151,12 @@ var (
 				Name: integreatlyv1alpha1.UninstallCloudResourcesStage,
 				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
 					integreatlyv1alpha1.ProductCloudResources: {Name: integreatlyv1alpha1.ProductCloudResources},
+				},
+			},
+			{
+				Name: integreatlyv1alpha1.UninstallObservabilityStage,
+				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
+					integreatlyv1alpha1.ProductObservability: {Name: integreatlyv1alpha1.ProductObservability},
 				},
 			},
 			{


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-1880

# What
This PR implements the uninstallation of the observability operator so that when RHOAM is triggered to uninstall, OO will remove itself and its namespaces.

# Verification steps

1. Target a cluster and install RHOAM using this pull request.
2. Once the installation is complete, trigger RHOAM to begin its uninstall: `oc delete rhmi rhoam`
3. Manually delete the OO CR in the operator namespace: `oc delete observability -n redhat-rhoam-observability-operator observability-stack`
      * This step is only required until the newest version of the observability-operator is released which will incorporate the changes made in [MGDSTRM-5246](https://issues.redhat.com/browse/MGDSTRM-5246)
4. Wait for the uninstallation to complete; this should satisfy the verification.
