### PR TITLE
[MGDAPI-2715] feat: specify prometheus & altermenager version for observability

### DIFF
--- a/pkg/config/observability.go
+++ b/pkg/config/observability.go
@@ -93,3 +93,11 @@ func (m *Observability) GetDashboards(installType integreatlyv1alpha1.Installati
 		return rhmiTemplateList
 	}
 }
+
+func (m *Observability) GetAlertManagerVersion() string {
+	return "v0.22.2"
+}
+
+func (m *Observability) GetPrometheusVersion() string {
+	return "v2.29.2"
+}

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -297,6 +297,8 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 					},
 				},
 				AlertManagerConfigSecret: config.AlertManagerConfigSecretName,
+				PrometheusVersion:        r.Config.GetPrometheusVersion(),
+				AlertManagerVersion:      r.Config.GetAlertManagerVersion(),
 			},
 			ResyncPeriod: "1h",
 		}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2715
# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Install sthe following version for observability:
-  prometheusVersion: v2.29.2
-  alertManagerVersion: v0.22.2

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Checkout this branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local 
make code/run
```
* Once observability stage is installed:
  * Verify Prometheus version installed is `v2.29.2` under Status -> Runtime Information & Build Information
![Screenshot from 2021-09-27 13-29-37](https://user-images.githubusercontent.com/24636860/134916692-b0542e9b-11ed-49ac-b029-d019d3a8473d.png)

  * Verify alert manager version installed in `v0.22.2` under Status -> Version Information
![Screenshot from 2021-09-27 13-28-48](https://user-images.githubusercontent.com/24636860/134934515-73fbbd3e-1e74-4444-bc05-bc57982c0146.png)


