### PR TITLE
[MGDAPI-2714] feat: specify prometheus & alertmanger route names in obsersability

### DIFF
--- a/pkg/config/observability.go
+++ b/pkg/config/observability.go
@@ -101,3 +101,11 @@ func (m *Observability) GetAlertManagerVersion() string {
 func (m *Observability) GetPrometheusVersion() string {
 	return "v2.29.2"
 }
+
+func (m *Observability) GetPrometheusRouteName() string {
+	return "prometheus-route"
+}
+
+func (m *Observability) GetAlertManagerRouteName() string {
+	return "alertmanager-route"
+}

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -29,9 +29,8 @@ const (
 	defaultInstallationNamespace = "observability"
 
 	// alert manager configuration
-	alertManagerRouteName = "kafka-alertmanager"
-	configMapNoInit       = "observability-operator-no-init"
-	observabilityName     = "observability-stack"
+	configMapNoInit   = "observability-operator-no-init"
+	observabilityName = "observability-stack"
 )
 
 type Reconciler struct {
@@ -162,7 +161,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = monitoringcommon.ReconcileAlertManagerSecrets(ctx, client, r.installation, r.Config.GetNamespace(), alertManagerRouteName)
+	phase, err = monitoringcommon.ReconcileAlertManagerSecrets(ctx, client, r.installation, r.Config.GetNamespace(), r.Config.GetAlertManagerRouteName())
 	r.log.Infof("ReconcileAlertManagerConfigSecret", l.Fields{"phase": phase})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		if err != nil {
@@ -299,6 +298,8 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 				AlertManagerConfigSecret: config.AlertManagerConfigSecretName,
 				PrometheusVersion:        r.Config.GetPrometheusVersion(),
 				AlertManagerVersion:      r.Config.GetAlertManagerVersion(),
+				PrometheusRoute:          r.Config.GetPrometheusRouteName(),
+				AlertManagerRoute:        r.Config.GetAlertManagerRouteName(),
 			},
 			ResyncPeriod: "1h",
 		}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2714
# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

Specify the following names for observability:

- prometheusRoute: prometheus-route
- alertManagerRoute: alertmanager-route

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

* Checkout this branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local 
make code/run
```
* Once observability stage is installed:
  * Verify alert manager route with name `alertmanager-route` is present
  ```
  oc get routes alertmanager-route -n redhat-rhoam-observability
  ```
  * Verify you can login to alertmanager using the route
  * Verify prometheus route with name `prometheus-route` is present
  ```
  oc get routes prometheus-route -n redhat-rhoam-observability
  ```
  * Verify you can login to prometheus using the route