### PR TITLE
add additional scrape config for prometheus to scrape metric

### DIFF
--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -294,7 +294,20 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 				DisableDeadmansSnitch:   &disabled,
 				DisableBlackboxExporter: nil,
 				SelfSignedCerts:         nil,
-				FederatedMetrics:        nil,
+				FederatedMetrics: []string{
+					"'kubelet_volume_stats_used_bytes{endpoint=\"https-metrics\",namespace=~\"redhat-rhoam-.*\"}'",
+					"'kubelet_volume_stats_available_bytes{endpoint=\"https-metrics\",namespace=~\"redhat-rhoam-.*\"}'",
+					"'kubelet_volume_stats_capacity_bytes{endpoint=\"https-metrics\",namespace=~\"redhat-rhoam-.*\"}'",
+					"'haproxy_backend_http_responses_total{route=~\"^keycloak.*\",exported_namespace=~\"redhat-rhoam-.*sso$\"}'",
+					"'{ service=\"kube-state-metrics\" }'",
+					"'{ service=\"node-exporter\" }'",
+					"'{ __name__=~\"node_namespace_pod_container:.*\" }'",
+					"'{ __name__=~\"node:.*\" }'",
+					"'{ __name__=~\"instance:.*\" }'",
+					"'{ __name__=~\"container_memory_.*\" }'",
+					"'{ __name__=~\":node_memory_.*\" }'",
+					"'{ __name__=~\"csv_.*\" }'",
+				},
 				PodMonitorLabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"monitoring-key": r.Config.GetLabelSelector(),


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2680

# What
Add additional scrape config copied from https://github.com/integr8ly/integreatly-operator/blob/master/templates/monitoring/jobs/openshift_monitoring_federation.yaml#L13-L24

# Verification steps
Deploy the operator via olm using this index -> `quay.io/laurafitzgerald/rhoam-index:1.13.0-install`

Verify that the observability contains the following block ->
```
federatedMetrics:
      - >-
        'kubelet_volume_stats_used_bytes{endpoint="https-metrics",namespace=~"redhat-rhoam-.*"}'
      - >-
        'kubelet_volume_stats_available_bytes{endpoint="https-metrics",namespace=~"redhat-rhoam-.*"}'
      - >-
        'kubelet_volume_stats_capacity_bytes{endpoint="https-metrics",namespace=~"redhat-rhoam-.*"}'
      - >-
        'haproxy_backend_http_responses_total{route=~"^keycloak.*",
        exported_namespace=~"redhat-rhoam-.*sso$"}'
      - '''{ service="kube-state-metrics" }'''
      - '''{ service="node-exporter" }'''
      - '''{ __name__=~"node_namespace_pod_container:.*" }'''
      - '''{ __name__=~"node:.*" }'''
      - '''{ __name__=~"instance:.*" }'''
      - '''{ __name__=~"container_memory_.*" }'''
      - '''{ __name__=~":node_memory_.*" }'''
      - '''{ __name__=~"csv_.*" }'''
```


verify that the secret `additional-scrape-configs` contains the following block 
```
match[]: ['kubelet_volume_stats_used_bytes{endpoint="https-metrics",namespace=~"redhat-rhoam-.*"}','kubelet_volume_stats_available_bytes{endpoint="https-metrics",namespace=~"redhat-rhoam-.*"}','kubelet_volume_stats_capacity_bytes{endpoint="https-metrics",namespace=~"redhat-rhoam-.*"}','haproxy_backend_http_responses_total{route=~"^keycloak.*", exported_namespace=~"redhat-rhoam-.*sso$"}','{ service="kube-state-metrics" }','{ service="node-exporter" }','{ __name__=~"node_namespace_pod_container:.*" }','{ __name__=~"node:.*" }','{ __name__=~"instance:.*" }','{ __name__=~"container_memory_.*" }','{ __name__=~":node_memory_.*" }','{ __name__=~"csv_.*" }']
```

Verify that metrics are present in promethues by navigating to prometheus and running some queries.
