### PR TITLE
Moving alerts to observability operator namespace

### DIFF
--- a/apis/v1alpha1/rhmi_types.go
+++ b/apis/v1alpha1/rhmi_types.go
@@ -59,6 +59,7 @@ var (
 	UninstallMonitoringStage     StageName = "uninstall - monitoring"
 	UninstallObservabilityStage  StageName = "uninstall - observability"
 	UninstallCloudResourcesStage StageName = "uninstall - cloud-resources"
+	UninstallBootstrap           StageName = "uninstall - bootstrap"
 
 	ProductAMQStreams          ProductName = "amqstreams"
 	ProductAMQOnline           ProductName = "amqonline"

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -78,6 +78,29 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, serverClient k8sclient.Client, installationQuota *quota.Quota, request ctrl.Request) (integreatlyv1alpha1.StatusPhase, error) {
 	r.log.Info("Reconciling bootstrap stage")
 
+	if integreatlyv1alpha1.IsRHOAM(rhmiv1alpha1.InstallationType(r.installation.Spec.Type)) {
+		observabilityConfig, err := r.ConfigManager.ReadObservability()
+		if err != nil {
+			return rhmiv1alpha1.PhaseFailed, err
+		}
+
+		uninstall := false
+		if installation.DeletionTimestamp != nil {
+			uninstall = true
+		}
+
+		phase, err := r.ReconcileFinalizer(ctx, serverClient, installation, string(observabilityConfig.GetProductName()), uninstall, func() (integreatlyv1alpha1.StatusPhase, error) {
+			phase, err := resources.RemoveNamespace(ctx, installation, serverClient, observabilityConfig.GetNamespace(), r.log)
+			if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+				return phase, err
+			}
+			return integreatlyv1alpha1.PhaseCompleted, nil
+		}, r.log)
+		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+			events.HandleError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
+			return phase, err
+		}
+	}
 	phase, err := r.reconcileOauthSecrets(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile oauth secrets", err)
@@ -138,6 +161,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		events.HandleError(r.recorder, installation, phase, "Failed to check rate limit alert config settings", err)
 		return phase, errors.Wrap(err, "failed to check rate limit alert config settings")
 	}
+
+	if integreatlyv1alpha1.IsRHOAM(rhmiv1alpha1.InstallationType(r.installation.Spec.Type)) {
+		observabilityConfig, err := r.ConfigManager.ReadObservability()
+		if err != nil {
+			return rhmiv1alpha1.PhaseFailed, err
+		}
+		phase, err = r.ReconcileNamespace(ctx, observabilityConfig.GetNamespace(), installation, serverClient, log)
+		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+			events.HandleError(r.recorder, installation, phase, "Failed to create observability operand namespace", err)
+			return phase, errors.Wrap(err, "failed to create observability operand namespace")
+		}
+	}
+
 	// temp code for rhmi 2.8 to 2.9.0 upgrades, remove this when all clusters upgraded to 2.9.0
 	r.deleteObsoleteService(ctx, serverClient)
 

--- a/controllers/rhmi/prometheusRules.go
+++ b/controllers/rhmi/prometheusRules.go
@@ -2,13 +2,13 @@ package controllers
 
 import (
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/products/observability"
 	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
-	"github.com/integr8ly/integreatly-operator/pkg/products/monitoring"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 )
 
@@ -34,62 +34,69 @@ func getAddonName(installation *integreatlyv1alpha1.RHMI) string {
 func (r *RHMIReconciler) newAlertsReconciler(installation *integreatlyv1alpha1.RHMI) resources.AlertReconciler {
 	installationName := installationNames[installation.Spec.Type]
 
+	alerts := []resources.AlertConfiguration{
+		{
+			AlertName: fmt.Sprintf("%s-installation-alerts", installationName),
+			Namespace: observability.OpenshiftMonitoringNamespace,
+			GroupName: fmt.Sprintf("%s-installation.rules", installationName),
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: fmt.Sprintf("%sOperatorInstallDelayed", strings.ToUpper(installationName)),
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlOperatorInstallDelayed,
+						"message": fmt.Sprintf("%s operator is taking more than 2 hours to go to a complete stage", strings.ToUpper(installationName)),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+", version="" }`, installationName)),
+					For:    "120m",
+					Labels: map[string]string{"severity": "critical", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
+				},
+			},
+		},
+		{
+			AlertName: fmt.Sprintf("%s-upgrade-alerts", installationName),
+			Namespace: observability.OpenshiftMonitoringNamespace,
+			GroupName: fmt.Sprintf("%s-upgrade.rules", installationName),
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: fmt.Sprintf("%sUpgradeExpectedDurationExceeded", strings.ToUpper(installationName)),
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlUpgradeExpectedDurationExceeded,
+						"message": fmt.Sprintf("%s operator upgrade is taking more than 60 minutes", strings.ToUpper(installationName)),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+",version=~".+"} and (absent((%s_version{job=~"%s.+"} * on(version) csv_succeeded{exported_namespace=~"%s"})) or %s_version)`, installationName, installationName, installationName, installation.Namespace, installationName)),
+					For:    "60m",
+					Labels: map[string]string{"severity": "critical", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
+				},
+			},
+		},
+	}
+
+	if !integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installation.Spec.Type)) {
+		installationAlert := resources.AlertConfiguration{
+			AlertName: fmt.Sprintf("%s-installation-controller-alerts", installationName),
+			Namespace: installation.Namespace,
+			GroupName: fmt.Sprintf("%s-installation.rules", installationName),
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: fmt.Sprintf("%sInstallationControllerIsInReconcilingErrorState", strings.ToUpper(installationName)),
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": fmt.Sprintf("%s operator has finished installing, but has been in a error state while reconciling for 5 of the last 10 minutes", strings.ToUpper(installationName)),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("%s_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='error'}[5m]) > 0", installationName)),
+					For:    "10m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+			},
+		}
+
+		alerts = append(alerts, installationAlert)
+	}
+
 	return &resources.AlertReconcilerImpl{
 		ProductName:  "installation",
 		Installation: installation,
 		Log:          log,
-		Alerts: []resources.AlertConfiguration{
-			{
-				AlertName: fmt.Sprintf("%s-installation-controller-alerts", installationName),
-				Namespace: installation.Namespace,
-				GroupName: fmt.Sprintf("%s-installation.rules", installationName),
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: fmt.Sprintf("%sInstallationControllerIsInReconcilingErrorState", strings.ToUpper(installationName)),
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": fmt.Sprintf("%s operator has finished installing, but has been in a error state while reconciling for 5 of the last 10 minutes", strings.ToUpper(installationName)),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("%s_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='error'}[5m]) > 0", installationName)),
-						For:    "10m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-				},
-			},
-			{
-				AlertName: fmt.Sprintf("%s-installation-alerts", installationName),
-				Namespace: monitoring.OpenshiftMonitoringNamespace,
-				GroupName: fmt.Sprintf("%s-installation.rules", installationName),
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: fmt.Sprintf("%sOperatorInstallDelayed", strings.ToUpper(installationName)),
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlOperatorInstallDelayed,
-							"message": fmt.Sprintf("%s operator is taking more than 2 hours to go to a complete stage", strings.ToUpper(installationName)),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+", version="" }`, installationName)),
-						For:    "120m",
-						Labels: map[string]string{"severity": "critical", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
-					},
-				},
-			},
-			{
-				AlertName: fmt.Sprintf("%s-upgrade-alerts", installationName),
-				Namespace: monitoring.OpenshiftMonitoringNamespace,
-				GroupName: fmt.Sprintf("%s-upgrade.rules", installationName),
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: fmt.Sprintf("%sUpgradeExpectedDurationExceeded", strings.ToUpper(installationName)),
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlUpgradeExpectedDurationExceeded,
-							"message": fmt.Sprintf("%s operator upgrade is taking more than 60 minutes", strings.ToUpper(installationName)),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+",version=~".+"} and (absent((%s_version{job=~"%s.+"} * on(version) csv_succeeded{exported_namespace=~"%s"})) or %s_version)`, installationName, installationName, installationName, installation.Namespace, installationName)),
-						For:    "60m",
-						Labels: map[string]string{"severity": "critical", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
-					},
-				},
-			},
-		},
+		Alerts:       alerts,
 	}
 }

--- a/controllers/rhmi/types.go
+++ b/controllers/rhmi/types.go
@@ -88,6 +88,9 @@ var (
 					integreatlyv1alpha1.ProductMonitoringSpec: {Name: integreatlyv1alpha1.ProductMonitoringSpec},
 				},
 			},
+			{
+				Name: integreatlyv1alpha1.UninstallBootstrap,
+			},
 		},
 	}
 	allManagedApiStages = &Type{

--- a/pkg/config/observability.go
+++ b/pkg/config/observability.go
@@ -44,6 +44,14 @@ func (m *Observability) SetNamespace(newNamespace string) {
 	m.Config["NAMESPACE"] = newNamespace
 }
 
+func (m *Observability) GetNamespacePrefix() string {
+	return m.Config["NAMESPACE_PREFIX"]
+}
+
+func (m *Observability) SetNamespacePrefix(newNamespacePrefix string) {
+	m.Config["NAMESPACE_PREFIX"] = newNamespacePrefix
+}
+
 func (m *Observability) Read() ProductConfig {
 	return m.Config
 }

--- a/pkg/products/grafana/prometheusRules.go
+++ b/pkg/products/grafana/prometheusRules.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -11,15 +12,30 @@ import (
 
 func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string) resources.AlertReconciler {
 	installationName := resources.InstallationNames[installType]
+
+	namespace := r.Config.GetOperatorNamespace()
+	alertNamePrefix := ""
+
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
+		observabilityConfig, err := r.ConfigManager.ReadObservability()
+		if err != nil {
+			logger.Warning("failed to get observability config")
+			return nil
+		}
+
+		namespace = observabilityConfig.GetNamespace()
+		alertNamePrefix = "customer-monitoring-"
+	}
+
 	return &resources.AlertReconcilerImpl{
 		Installation: r.installation,
 		Log:          logger,
 		ProductName:  "Grafana",
 		Alerts: []resources.AlertConfiguration{
 			{
-				AlertName: "ksm-endpoint-alerts",
+				AlertName: alertNamePrefix + "ksm-endpoint-alerts",
 				GroupName: "grafana-operator-endpoint.rules",
-				Namespace: r.Config.GetOperatorNamespace(),
+				Namespace: namespace,
 				Rules: []monitoringv1.Rule{
 					{
 						Alert: "GrafanaOperatorRhmiRegistryCsServiceEndpointDown",
@@ -44,9 +60,9 @@ func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string) res
 				},
 			},
 			{
-				AlertName: "ksm-grafana-alerts",
+				AlertName: alertNamePrefix + "ksm-grafana-alerts",
 				GroupName: "general.rules",
-				Namespace: r.Config.GetOperatorNamespace(),
+				Namespace: namespace,
 				Rules: []monitoringv1.Rule{
 					{
 						Alert: "GrafanaOperatorPod",

--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -3,6 +3,7 @@ package marin3r
 import (
 	"errors"
 	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"regexp"
 	"strconv"
 	"strings"
@@ -25,7 +26,18 @@ func (r *Reconciler) newAlertsReconciler(grafanaDashboardURL string) (resources.
 	if err != nil {
 		return nil, err
 	}
-	alerts, err := mapAlertsConfiguration(r.log, r.Config.GetNamespace(), r.RateLimitConfig.Unit, r.RateLimitConfig.RequestsPerUnit, requestsAllowedPerSecond, r.AlertsConfig, grafanaDashboardURL, r.installation.Spec.Type)
+	namespace := r.Config.GetNamespace()
+
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
+		observabilityConfig, err := r.ConfigManager.ReadObservability()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get observability config: %e", err)
+		}
+
+		namespace = observabilityConfig.GetNamespace()
+	}
+
+	alerts, err := mapAlertsConfiguration(r.log, namespace, r.RateLimitConfig.Unit, r.RateLimitConfig.RequestsPerUnit, requestsAllowedPerSecond, r.AlertsConfig, grafanaDashboardURL, r.installation.Spec.Type)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create alerts from configuration: %w", err)
 	}
@@ -45,6 +57,11 @@ func mapAlertsConfiguration(logger l.Logger, namespace, rateLimitUnit string, ra
 	result := make([]resources.AlertConfiguration, 0, len(alertsConfig))
 
 	for alertName, alertConfig := range alertsConfig {
+
+		if installationName == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+			alertName = "marin3r-" + alertName
+		}
+
 		switch alertConfig.Type {
 		case marin3rconfig.AlertTypeSpike:
 			expr := fmt.Sprintf(

--- a/pkg/products/marin3r/rejectedRequestsPrometheusRules.go
+++ b/pkg/products/marin3r/rejectedRequestsPrometheusRules.go
@@ -2,6 +2,7 @@ package marin3r
 
 import (
 	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/marin3r/config"
@@ -14,6 +15,20 @@ const rejectedRequestsAlertExpr = "abs(clamp_min(increase(limited_calls[1m]) - %
 
 func (r *Reconciler) newRejectedRequestsAlertsReconciler(logger l.Logger, installType string) (resources.AlertReconciler, error) {
 	installationName := resources.InstallationNames[installType]
+
+	namespace := r.Config.GetNamespace()
+	alertName := "rejected-requests"
+
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
+		observabilityConfig, err := r.ConfigManager.ReadObservability()
+		if err != nil {
+			logger.Warning("failed to get observability config")
+			return nil, err
+		}
+
+		namespace = observabilityConfig.GetNamespace()
+		alertName = "marin3r-rejected-requests"
+	}
 
 	limitPerMinute, err := config.ConvertRate(
 		r.RateLimitConfig.Unit,
@@ -30,9 +45,9 @@ func (r *Reconciler) newRejectedRequestsAlertsReconciler(logger l.Logger, instal
 		Log:          logger,
 		Alerts: []resources.AlertConfiguration{
 			{
-				AlertName: "rejected-requests",
+				AlertName: alertName,
 				GroupName: "rejected-requests.rules",
-				Namespace: r.Config.GetNamespace(),
+				Namespace: namespace,
 				Rules: []monitoringv1.Rule{
 					{
 						Alert: "RHOAMApiUsageRejectedRequestsMismatch",

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -1,0 +1,366 @@
+package observability
+
+import (
+	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"strings"
+)
+
+func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) resources.AlertReconciler {
+	installationName := resources.InstallationNames[installType]
+	nsPrefix := r.installation.Spec.NamespacePrefix
+	namespace := r.Config.GetNamespace()
+
+	return &resources.AlertReconcilerImpl{
+		ProductName:  "monitoring",
+		Installation: r.installation,
+		Log:          logger,
+		Alerts: []resources.AlertConfiguration{
+			{
+				AlertName: "backup-monitoring-alerts",
+				GroupName: "general.rules",
+				Namespace: namespace,
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "JobRunningTimeExceeded",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": " Job {{ $labels.namespace }} / {{ $labels.job  }} has been running for longer than 300 seconds",
+						},
+						Expr:   intstr.FromString("time() - (max(kube_job_status_active * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name) * ON(job_name) GROUP_RIGHT() max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name, namespace, label_cronjob_name) > 0) > 300 "),
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "JobRunningTimeExceeded",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": " Job {{ $labels.namespace }} / {{ $labels.job  }} has been running for longer than 600 seconds",
+						},
+						Expr:   intstr.FromString("time() - (max(kube_job_status_active * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name) * ON(job_name) GROUP_RIGHT() max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name, namespace, label_cronjob_name) > 0) > 600 "),
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "CronJobNotRunInThreshold",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": " CronJob {{ $labels.namespace }} / {{ $labels.label_cronjob_name }} has not started a Job in 25 hours",
+						},
+						Expr: intstr.FromString("(time() - (max( kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'} ) BY (job_name, label_cronjob_name) == ON(label_cronjob_name) GROUP_LEFT() max( kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'} ) BY (label_cronjob_name))) > 60*60*25"),
+					},
+					{
+						Alert: "CronJobsFailed",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Job {{ $labels.namespace  }} / {{  $labels.job  }} has failed",
+						},
+						Expr:   intstr.FromString("clamp_max(max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'} ) BY (job_name, label_cronjob_name, namespace) == ON(label_cronjob_name) GROUP_LEFT() max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (label_cronjob_name), 1) * ON(job_name) GROUP_LEFT() kube_job_status_failed > 0"),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+				},
+			},
+
+			{
+				AlertName: "ksm-alerts",
+				Namespace: namespace,
+				GroupName: "general.rules",
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "KubePodCrashLooping",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Pod {{  $labels.namespace  }} / {{  $labels.pod  }} ({{  $labels.container  }}) is restarting {{  $value  }} times every 10 minutes; for the last 15 minutes",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("rate(kube_pod_container_status_restarts_total{job='kube-state-metrics',namespace=~'%s.*'}[10m]) * 60 * 5 > 0", r.Config.GetNamespacePrefix())),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "KubePodNotReady",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Pod {{ $labels.namespace }} / {{ $labels.pod }}  has been in a non-ready state for longer than 15 minutes.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("sum by(pod, namespace) (kube_pod_status_phase{phase=~'Pending|Unknown', namespace=~'%s.*'}) > 0", r.Config.GetNamespacePrefix())),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "KubePodImagePullBackOff",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Pod {{ $labels.namespace }} / {{  $labels.pod  }} has been unable to pull its image for longer than 5 minutes.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_pod_container_status_waiting_reason{reason='ImagePullBackOff',namespace=~'%s.*'} > 0", r.Config.GetNamespacePrefix())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "KubePodBadConfig",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": " Pod {{ $labels.namespace  }} / {{  $labels.pod  }} has been unable to start due to a bad configuration for longer than 5 minutes",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_pod_container_status_waiting_reason{reason='CreateContainerConfigError',namespace=~'%s.*'} > 0", r.Config.GetNamespacePrefix())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "KubePodStuckCreating",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Pod {{  $labels.namespace }} / {{  $labels.pod  }} has been trying to start for longer than 15 minutes - this could indicate a configuration error.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_pod_container_status_waiting_reason{reason='ContainerCreating',namespace=~'%s.*'} > 0", r.Config.GetOperatorNamespace())),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "ClusterSchedulableMemoryLow",
+						Annotations: map[string]string{
+							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
+							"message": "The cluster has {{  $value }} percent of memory requested and unavailable for scheduling for longer than 15 minutes.",
+						},
+						Expr:   intstr.FromString("((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests{resource='memory'} * on(node) group_left() (sum by(node) (kube_node_role{role='worker'}  == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase='Running'}) == 1)))) / ((sum((kube_node_role{role='worker'}  == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable{resource='memory'})))))) * 100 > 85"),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "ClusterSchedulableCPULow",
+						Annotations: map[string]string{
+							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
+							"message": "The cluster has {{ $value }} percent of CPU cores requested and unavailable for scheduling for longer than 15 minutes.",
+						},
+						Expr:   intstr.FromString("((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests{resource='cpu'} * on(node) group_left() (sum by(node) (kube_node_role{role='worker'} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase='Running'}) == 1)))) / ((sum((kube_node_role{role='worker'} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable{resource='cpu'})))))) * 100 > 85"),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "PVCStorageAvailable",
+						Annotations: map[string]string{
+							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
+							"message": "The {{  $labels.persistentvolumeclaim  }} PVC has has been {{ $value }} percent full for longer than 15 minutes.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("((sum by(persistentvolumeclaim, namespace) (kubelet_volume_stats_used_bytes{namespace=~'%s.*'})) / (sum by(persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace=~'%s.*'}))) * 100 > 85", r.Config.GetNamespacePrefix(), r.Config.GetNamespacePrefix())),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "PVCStorageMetricsAvailable",
+						Annotations: map[string]string{
+							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
+							"message": "PVC storage metrics are not available",
+						},
+						Expr:   intstr.FromString("absent(kubelet_volume_stats_available_bytes) == 1 or absent(kubelet_volume_stats_capacity_bytes) == 1 or absent(kubelet_volume_stats_used_bytes) == 1 or absent(kube_persistentvolumeclaim_resource_requests_storage_bytes) == 1"),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "KubePersistentVolumeFillingUp4h",
+						Annotations: map[string]string{
+							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/pvc_storage.asciidoc#pvcstoragewillfillin4hours",
+							"message": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(predict_linear(kubelet_volume_stats_available_bytes{job='kubelet', namespace=~'%s.*'} [6h], 4 * 24 * 3600) <= 0 and kubelet_volume_stats_available_bytes{job='kubelet', namespace=~'%s.*'}  / kubelet_volume_stats_capacity_bytes{job='kubelet'} < 0.15)", r.Config.GetNamespacePrefix(), r.Config.GetNamespacePrefix())),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "KubePersistentVolumeFillingUp",
+						Annotations: map[string]string{
+							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/pvc_storage.asciidoc#kubepersistentvolumefillingup",
+							"message": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(kubelet_volume_stats_available_bytes{job='kubelet', namespace=~'%s.*'} / kubelet_volume_stats_capacity_bytes{job='kubelet', namespace=~'%s.*'} < 0.03)", r.Config.GetNamespacePrefix(), r.Config.GetNamespacePrefix())),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+
+					{
+						Alert: "PersistentVolumeErrors",
+						Annotations: map[string]string{
+							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/pvc_storage.asciidoc#persistentvolumeerrors",
+							"message": "The PVC {{  $labels.persistentvolumeclaim  }} is in status {{  $labels.phase  }} in namespace {{  $labels.namespace }} ",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(sum by(persistentvolumeclaim, namespace, phase) (kube_persistentvolumeclaim_status_phase{phase=~'Failed|Pending|Lost', namespace=~'%s.*'})) > 0", r.Config.GetNamespacePrefix())),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+				},
+			},
+
+			{
+				AlertName: "ksm-endpoint-alerts",
+				Namespace: namespace,
+				GroupName: "middleware-monitoring-operator-endpoint.rules",
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "RHMIMiddlewareMonitoringOperatorAlertmanagerOperatedServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='alertmanager-operated', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "RHMIMiddlewareMonitoringOperatorAlertmanagerServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='alertmanager-service', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "RHMIMiddlewareMonitoringOperatorApplicationMonitoringMetricsServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='application-monitoring-operator-metrics', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "RHMIMiddlewareMonitoringOperatorGrafanaServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='grafana-service', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "RHMIMiddlewareMonitoringOperatorPrometheusOperatedServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='prometheus-operated', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "RHMIMiddlewareMonitoringOperatorPrometheusServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='prometheus-service', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "RHMIMiddlewareMonitoringOperatorRhmiRegistryCsServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+				},
+			},
+			{
+				AlertName: "install-upgrade-alerts",
+				Namespace: namespace,
+				GroupName: "general.rules",
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "RHMICSVRequirementsNotMet",
+						Annotations: map[string]string{
+							"message": "RequirementsNotMet for CSV '{{$labels.name}}' in namespace '{{$labels.namespace}}'. Phase is {{$labels.phase}}",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("csv_abnormal{phase=~'Pending|Failed',exported_namespace=~'%s.*'}", r.Config.GetNamespacePrefix())),
+						For:    "15m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+				},
+			},
+			{
+				AlertName: "multi-az-pod-distribution",
+				Namespace: namespace,
+				GroupName: "general.rules",
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "MultiAZPodDistribution",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlPodDistributionIncorrect,
+							"message": "Pod {{  $labels.namespace  }} / {{  $labels.pod  }} ({{  $labels.container  }}) is incorretly distributed to the zone {{  $value  }} ; for the last 5 minutes",
+						},
+						Expr:   intstr.FromString(installationName + "_version{to_version=\"\"} and (count by(namespace, created_by_name, label_topology_kubernetes_io_zone) (kube_pod_info{namespace=~'" + nsPrefix + ".*', created_by_kind!=\"<none>\"} == on(node) group_left(label_topology_kubernetes_io_zone) kube_node_labels) == on (namespace, created_by_name)(count by(namespace, created_by_name) (kube_pod_info{namespace=~'" + nsPrefix + ".*', created_by_kind!=\"<none>\"}) > 1) > scalar((count(count by (label_topology_kubernetes_io_zone) (kube_node_labels)) >= bool 2) == 1))"),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+				},
+			},
+			{
+				AlertName: "test-alerts",
+				Namespace: namespace,
+				GroupName: "test.rules",
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "TestFireCriticalAlert",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlTestFireAlerts,
+							"message": fmt.Sprintf("This is occasional Test Fire alert from Team SRE"),
+						},
+						Expr:   intstr.FromString("count(kube_secret_info{namespace='" + r.Config.GetOperatorNamespace() + "', secret='cj3cssrec'}) > 0"),
+						For:    "10s",
+						Labels: map[string]string{"severity": "critical", "product": "secret"},
+					},
+					{
+						Alert: "TestFireWarningAlert",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlTestFireAlerts,
+							"message": fmt.Sprintf("This is occasional Test Fire alert from Team SRE"),
+						},
+						Expr:   intstr.FromString("count(kube_secret_info{namespace='" + r.Config.GetOperatorNamespace() + "', secret='wj3cssrew'}) > 0"),
+						For:    "10s",
+						Labels: map[string]string{"severity": "warning", "product": "secret"},
+					},
+				},
+			},
+			{
+				AlertName: "prometheus-application-monitoring-rules",
+				GroupName: "general.rules",
+				Namespace: namespace,
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "DeadMansSwitch",
+						Annotations: map[string]string{
+							"message": " This is a DeadMansSwitch meant to ensure that the entire Alerting pipeline is functional.",
+						},
+						Expr:   intstr.FromString("vector(1)"),
+						Labels: map[string]string{"severity": "none"},
+					},
+				},
+			},
+			{
+				AlertName: fmt.Sprintf("%s-installation-controller-alerts", installationName),
+				Namespace: namespace,
+				GroupName: fmt.Sprintf("%s-installation.rules", installationName),
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: fmt.Sprintf("%sInstallationControllerIsInReconcilingErrorState", strings.ToUpper(installationName)),
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": fmt.Sprintf("%s operator has finished installing, but has been in a error state while reconciling for 5 of the last 10 minutes", strings.ToUpper(installationName)),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("%s_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='error'}[5m]) > 0", installationName)),
+						For:    "10m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -32,9 +32,10 @@ import (
 const (
 	defaultInstallationNamespace = "observability"
 
-	configMapNoInit    = "observability-operator-no-init"
-	observabilityName  = "observability-stack"
-	defaultProbeModule = "http_2xx"
+	configMapNoInit              = "observability-operator-no-init"
+	observabilityName            = "observability-stack"
+	defaultProbeModule           = "http_2xx"
+	OpenshiftMonitoringNamespace = "openshift-monitoring"
 )
 
 type Reconciler struct {
@@ -67,6 +68,9 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve observability config: %w", err)
 	}
+
+	config.SetNamespacePrefix(installation.Spec.NamespacePrefix)
+
 	if config.GetNamespace() == "" {
 		config.SetNamespace(ns)
 		err := configManager.WriteConfig(config)
@@ -214,6 +218,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 			r.log.Warning("Failure reconciling dashboards " + err.Error())
 		}
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile dashboards", err)
+		return phase, err
+	}
+
+	phase, err = r.newAlertsReconciler(r.log, r.installation.Spec.Type).ReconcileAlerts(ctx, client)
+	r.log.Infof("reconcilePrometheusRule", l.Fields{"phase": phase})
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)
+		return phase, err
+	}
+
+	// creates an alert to check for the presents of sendgrid smtp secret
+	phase, err = resources.CreateSmtpSecretExists(ctx, client, installation)
+	r.log.Infof("CreateSmtpSecretExistsRule", l.Fields{"phase": phase})
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile SendgridSmtpSecretExists alert", err)
 		return phase, err
 	}
 
@@ -385,6 +404,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 						},
 					},
 				},
+
 				AlertManagerConfigSecret: config.AlertManagerConfigSecretName,
 				PrometheusVersion:        r.Config.GetPrometheusVersion(),
 				AlertManagerVersion:      r.Config.GetAlertManagerVersion(),

--- a/pkg/products/rhsso/prometheusRules.go
+++ b/pkg/products/rhsso/prometheusRules.go
@@ -2,6 +2,7 @@ package rhsso
 
 import (
 	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"strings"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
@@ -12,14 +13,34 @@ import (
 
 func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) resources.AlertReconciler {
 	installationName := resources.InstallationNames[installType]
+
+	namespace := r.Config.GetNamespace()
+	operatorNamespace := r.Config.GetOperatorNamespace()
+	alertName := "ksm-endpoint-alerts"
+	operatorAlertName := "ksm-endpoint-alerts"
+
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
+		observabilityConfig, err := r.ConfigManager.ReadObservability()
+		if err != nil {
+			logger.Warning("failed to get observability config")
+			return nil
+		}
+
+		namespace = observabilityConfig.GetNamespace()
+		operatorNamespace = observabilityConfig.GetNamespace()
+
+		alertName = "rhsso-ksm-endpoint-alerts"
+		operatorAlertName = "rhsso-operator-ksm-endpoint-alerts"
+	}
+
 	return &resources.AlertReconcilerImpl{
 		ProductName:  "rhsso",
 		Installation: r.Installation,
 		Log:          logger,
 		Alerts: []resources.AlertConfiguration{
 			{
-				AlertName: "ksm-endpoint-alerts",
-				Namespace: r.Config.GetNamespace(),
+				AlertName: alertName,
+				Namespace: namespace,
 				GroupName: "rhsso-endpoint.rules",
 				Rules: []monitoringv1.Rule{
 					{
@@ -46,8 +67,8 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 			},
 
 			{
-				AlertName: "ksm-endpoint-alerts",
-				Namespace: r.Config.GetOperatorNamespace(),
+				AlertName: operatorAlertName,
+				Namespace: operatorNamespace,
 				GroupName: "rhsso-operator-endpoint.rules",
 				Rules: []monitoringv1.Rule{
 					{
@@ -78,7 +99,7 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 			//https://promtools.dev/alerts/errors
 			{
 				AlertName: "rhsso-slo-availability-alerts",
-				Namespace: r.Config.GetOperatorNamespace(),
+				Namespace: operatorNamespace,
 				GroupName: "rhsso-slo-availability.rules",
 				Rules: []monitoringv1.Rule{
 					{

--- a/pkg/products/rhssouser/prometheusRules.go
+++ b/pkg/products/rhssouser/prometheusRules.go
@@ -2,6 +2,7 @@ package rhssouser
 
 import (
 	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"strings"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -13,15 +14,35 @@ import (
 
 func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) resources.AlertReconciler {
 	installationName := resources.InstallationNames[installType]
+
+	namespace := r.Config.GetNamespace()
+	operatorNamespace := r.Config.GetOperatorNamespace()
+	alertName := "ksm-endpoint-alerts"
+	operatorAlertName := "ksm-endpoint-alerts"
+
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
+		observabilityConfig, err := r.ConfigManager.ReadObservability()
+		if err != nil {
+			logger.Warning("failed to get observability config")
+			return nil
+		}
+
+		namespace = observabilityConfig.GetNamespace()
+		operatorNamespace = observabilityConfig.GetNamespace()
+
+		alertName = "user-sso-ksm-endpoint-alerts"
+		operatorAlertName = "user-sso-operator-ksm-endpoint-alerts"
+	}
+
 	return &resources.AlertReconcilerImpl{
 		ProductName:  "RHSSO User",
 		Installation: r.Installation,
 		Log:          logger,
 		Alerts: []resources.AlertConfiguration{
 			{
-				AlertName: "ksm-endpoint-alerts",
+				AlertName: alertName,
 				GroupName: "user-rhsso-endpoint.rules",
-				Namespace: r.Config.GetNamespace(),
+				Namespace: namespace,
 				Rules: []monitoringv1.Rule{
 					{
 						Alert: "RHMIUserRhssoKeycloakServiceEndpointDown",
@@ -47,8 +68,8 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 			},
 
 			{
-				AlertName: "ksm-endpoint-alerts",
-				Namespace: r.Config.GetOperatorNamespace(),
+				AlertName: operatorAlertName,
+				Namespace: operatorNamespace,
 				GroupName: "user-rhsso-operator-endpoint.rules",
 				Rules: []monitoringv1.Rule{
 					{
@@ -79,7 +100,7 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 			//https://promtools.dev/alerts/errors
 			{
 				AlertName: "user-sso-slo-availability-alerts",
-				Namespace: r.Config.GetOperatorNamespace(),
+				Namespace: operatorNamespace,
 				GroupName: "user-sso-slo-availability.rules",
 				Rules: []monitoringv1.Rule{
 					{

--- a/pkg/products/threescale/envoy_prometheusRules.go
+++ b/pkg/products/threescale/envoy_prometheusRules.go
@@ -2,6 +2,7 @@ package threescale
 
 import (
 	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -12,15 +13,30 @@ import (
 func (r *Reconciler) newEnvoyAlertReconciler(logger l.Logger, installType string) resources.AlertReconciler {
 	installationName := resources.InstallationNames[installType]
 
+	namespace := r.Config.GetNamespace()
+	alertName := "ksm-marin3r-alerts"
+
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
+
+		observabilityConfig, err := r.ConfigManager.ReadObservability()
+		if err != nil {
+			logger.Warning("failed to get observability config")
+			return nil
+		}
+
+		namespace = observabilityConfig.GetNamespace()
+		alertName = "3scale-ksm-marin3r-alerts"
+	}
+
 	return &resources.AlertReconcilerImpl{
 		Installation: r.installation,
 		Log:          logger,
 		ProductName:  "3scale",
 		Alerts: []resources.AlertConfiguration{
 			{
-				AlertName: "ksm-marin3r-alerts",
+				AlertName: alertName,
 				GroupName: "general.rules",
-				Namespace: r.Config.GetNamespace(),
+				Namespace: namespace,
 				Rules: []monitoringv1.Rule{
 					{
 						Alert: "Marin3rEnvoyApicastStagingContainerDown",

--- a/pkg/products/threescale/prometheusRules.go
+++ b/pkg/products/threescale/prometheusRules.go
@@ -2,6 +2,7 @@ package threescale
 
 import (
 	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"net/http"
@@ -14,15 +15,33 @@ import (
 func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string) resources.AlertReconciler {
 	installationName := resources.InstallationNames[installType]
 
+	namespace := r.Config.GetNamespace()
+	operatorNamespace := r.Config.GetOperatorNamespace()
+	alertNamePrefix := ""
+	operatorAlertNamePrefix := ""
+
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
+		observabilityConfig, err := r.ConfigManager.ReadObservability()
+		if err != nil {
+			logger.Warning("failed to get observability config")
+			return nil
+		}
+
+		namespace = observabilityConfig.GetNamespace()
+		operatorNamespace = observabilityConfig.GetNamespace()
+		alertNamePrefix = "3scale-"
+		operatorAlertNamePrefix = "3scale-operator-"
+	}
+
 	return &resources.AlertReconcilerImpl{
 		Installation: r.installation,
 		Log:          logger,
 		ProductName:  "3scale",
 		Alerts: []resources.AlertConfiguration{
 			{
-				AlertName: "ksm-endpoint-alerts",
+				AlertName: alertNamePrefix + "ksm-endpoint-alerts",
 				GroupName: " 3scale-endpoint.rules",
-				Namespace: r.Config.GetNamespace(),
+				Namespace: namespace,
 				Rules: []monitoringv1.Rule{
 					{
 						Alert: "RHMIThreeScaleApicastProductionServiceEndpointDown",
@@ -128,9 +147,9 @@ func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string) res
 			},
 
 			{
-				AlertName: "ksm-endpoint-alerts",
+				AlertName: operatorAlertNamePrefix + "ksm-endpoint-alerts",
 				GroupName: " 3scale-operator-endpoint.rules",
-				Namespace: r.Config.GetOperatorNamespace(),
+				Namespace: operatorNamespace,
 				Rules: []monitoringv1.Rule{
 					{
 						Alert: "RHMIThreeScaleOperatorRhmiRegistryCsServiceEndpointDown",
@@ -155,9 +174,9 @@ func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string) res
 				},
 			},
 			{
-				AlertName: "ksm-3scale-user-alerts",
+				AlertName: alertNamePrefix + "ksm-3scale-user-alerts",
 				GroupName: "general.rules",
-				Namespace: r.Config.GetNamespace(),
+				Namespace: namespace,
 				Rules: []monitoringv1.Rule{
 					{
 						Alert: "ThreeScaleUserCreationFailed",
@@ -179,9 +198,9 @@ func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string) res
 			},
 
 			{
-				AlertName: "ksm-3scale-alerts",
+				AlertName: alertNamePrefix + "ksm-3scale-alerts",
 				GroupName: "general.rules",
-				Namespace: r.Config.GetNamespace(),
+				Namespace: namespace,
 				Rules: []monitoringv1.Rule{
 					{
 						Alert: "ThreeScaleApicastStagingPod",

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -34,6 +34,7 @@ import (
 
 	crov1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	croResources "github.com/integr8ly/cloud-resource-operator/pkg/resources"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -174,8 +175,13 @@ func CreateSmtpSecretExists(ctx context.Context, client k8sclient.Client, cr *v1
 		"severity": "warning",
 		"product":  installationName,
 	}
+
 	// create the rule
-	_, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlSendGridSmtpSecretExists, alertFor10Mins, alertExp, labels)
+	namespace := cr.Namespace
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(cr.Spec.Type)) {
+		namespace = "redhat-rhoam-observability"
+	}
+	_, err := reconcilePrometheusRule(ctx, client, ruleName, namespace, alertName, alertDescription, sopUrlSendGridSmtpSecretExists, alertFor10Mins, alertExp, labels)
 	if err != nil {
 		return v1alpha1.PhaseFailed, fmt.Errorf("failed to create sendgrid smtp exists rule err: %s", err)
 	}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2700

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Move the prometheus rules into the observability namespace so the namespace scaoped prometheus can pick up the alerts. 

Note the `redhat-rhoam-observability` namespace is created during the bootstrap stage the CRO reconciler needs to add rules to the namespace before the OO reconciler even starts.

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Verification 1
Check that partial install will be cleaned up correctly. 
- Partially install this branch
- Start the operator uninstall once the CRO namespace is created. 
- Expected the `redhat-rhoam-observability` namespace is removed.

## Verification 2
Check alerts are shown in promethus
- Fully install this branch
- navigate to the OO promethus `oc get routes -n redhat-rhoam-observability --no-headers | grep prometheus | awk '{print $2}' | xargs -I {} echo https://{}`
- Expected: under the alerts tab the alerts for the different products should be shown. Note https://github.com/valerymo/integreatly-operator/pull/17 is fixing the issues of firing alerts. 

## Verification 3
With both the bootstrap stage and observability operator managing the deletion of the `redhat-rhoam-observability` namespace. We need to check the full uninstall works as expected.
- Fully install this branch
- Uninstall the rhoam operator.
- Expected: All namespace are removed and the uninstall is successfully 