### PR TITLE
MGDAPI-2712 - Export Grafana dashboard & Prometheus alerts from SSO

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -3,6 +3,7 @@ package rhsso
 import (
 	"context"
 	"fmt"
+	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhssocommon"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -10,7 +11,6 @@ import (
 	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
 	"github.com/integr8ly/integreatly-operator/version"
 	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 
 	keycloakCommon "github.com/integr8ly/keycloak-client/pkg/common"
@@ -225,6 +225,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.newAlertsReconciler(r.Log, r.Installation.Spec.Type).ReconcileAlerts(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile alerts", err)
+		return phase, err
+	}
+
+	phase, err = r.exportDashboard(ctx, serverClient)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, "Failed to export dashboard to the observability namespace", err)
+		return phase, err
+	}
+
+	phase, err = r.ExportAlerts(ctx, serverClient, string(r.Config.GetProductName()), r.Config.GetNamespace())
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, "Failed to export alerts to the observability namespace", err)
 		return phase, err
 	}
 
@@ -555,6 +567,49 @@ func (r *Reconciler) createOrUpdateKeycloakUser(ctx context.Context, user keyclo
 		kcUser.Spec.User = user
 		return nil
 	})
+}
+
+func (r *Reconciler) exportDashboard(ctx context.Context, apiClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(r.Installation.Spec.Type)) {
+		dashboard := "keycloak"
+
+		ssoDB := &grafanav1alpha1.GrafanaDashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dashboard,
+				Namespace: r.Config.GetNamespace(),
+			},
+		}
+
+		err := apiClient.Get(ctx, k8sclient.ObjectKey{Name: ssoDB.Name, Namespace: ssoDB.Namespace}, ssoDB)
+		if err != nil {
+			return integreatlyv1alpha1.PhaseFailed, err
+		}
+
+		observabilityConfig, err := r.ConfigManager.ReadObservability()
+		if err != nil {
+			return integreatlyv1alpha1.PhaseFailed, err
+		}
+
+		observabilityDB := &grafanav1alpha1.GrafanaDashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dashboard,
+				Namespace: observabilityConfig.GetNamespace(),
+			},
+		}
+
+		opRes, err := controllerutil.CreateOrUpdate(ctx, apiClient, observabilityDB, func() error {
+			observabilityDB.Labels = ssoDB.Labels
+			observabilityDB.Spec = ssoDB.Spec
+			return nil
+		})
+		if err != nil {
+			return integreatlyv1alpha1.PhaseFailed, err
+		}
+		if opRes != controllerutil.OperationResultNone {
+			r.Log.Infof("Operation result grafana ssoDB", l.Fields{"grafanaDashboard": observabilityDB.Name, "result": opRes})
+		}
+	}
+	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
 func GetKeycloakUsers(ctx context.Context, serverClient k8sclient.Client, ns string) ([]keycloak.KeycloakAPIUser, error) {

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -285,6 +285,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		}
 	}
 
+	phase, err = r.ExportAlerts(ctx, serverClient, string(r.Config.GetProductName()), r.Config.GetNamespace())
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, "Failed to export alerts to the observability namespace", err)
+		return phase, err
+	}
+
 	productStatus.Host = r.Config.GetHost()
 	productStatus.Version = r.Config.GetProductVersion()
 	productStatus.OperatorVersion = r.Config.GetOperatorVersion()


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2712

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Prometheus and Grafana can not see outside of their namespace. The SSO operator creates dashboards and prometheus rules in its own namespace. This work exports the required CR's from the SSO namespaces into the correct namespace. 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Verification 1
Checking the Grafana dashborads. Metrics are missing from this PR, the dashboard will be missing information. As the dashboard allows to select which instance of SSO to display information on, only one dashboard is copied over.

- install this branch
- navigate to the Grafana instances `oc get routes -n redhat-rhoam-observability --no-headers | grep grafana | awk '{print $2}' | xargs -I {} xdg-open https://{}`
- Expected: dashboard called `keycloak-metrics` exists.

## Verification 2
Check alerts for both SSO instances are present. Also with the metrics missing some of these alerts are not working.

- install this branch
- navigate to the Prometheus instances `oc get routes -n redhat-rhoam-observability --no-headers | grep prometheus | awk '{print $2}' | xargs -I {} xdg-open https://{}`
- Go to the alerts tab.
- Expected: The follow files should be present
  - redhat-rhoam-observability-rhsso.yaml
  - redhat-rhoam-observability-rhssouser.yaml