### PR TITLE
[MGDAPI-2729] feat: set prometheus storage configuation in observability

### DIFF
--- a/pkg/config/observability.go
+++ b/pkg/config/observability.go
@@ -109,3 +109,11 @@ func (m *Observability) GetPrometheusRouteName() string {
 func (m *Observability) GetAlertManagerRouteName() string {
 	return "alertmanager-route"
 }
+
+func (m *Observability) GetPrometheusRetention() string {
+	return "45d"
+}
+
+func (m *Observability) GetPrometheusStorageRequest() string {
+	return "50Gi"
+}

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
@@ -313,6 +314,18 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 				},
 				MatchExpressions: nil,
 			},
+			Storage: &observability.Storage{PrometheusStorageSpec: &prometheus.StorageSpec{
+				VolumeClaimTemplate: prometheus.EmbeddedPersistentVolumeClaim{
+					Spec: v1.PersistentVolumeClaimSpec{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								"storage": resource.MustParse(r.Config.GetPrometheusStorageRequest()),
+							},
+						},
+					},
+				},
+			}},
+			Retention: r.Config.GetPrometheusRetention(),
 			SelfContained: &observability.SelfContained{
 				DisableRepoSync:         &disabled,
 				DisableObservatorium:    &disabled,


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2729

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Add prometheus storage configuration so data with be retained when pod moves between nodes on restarts

The configuration should be the same as the one used previously in AMO:
* https://github.com/integr8ly/integreatly-operator/blob/master/pkg/config/monitoring.go#L153-L159


# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Checkout this branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local
make code/run
```
* Once observability completes installation
  * Verify retention and storage is specified in Prometheus CR
  ```
   oc get prometheus kafka-prometheus -n redhat-rhoam-observability -o json | jq '.spec.storage'
   oc get prometheus kafka-prometheus -n redhat-rhoam-observability -o json | jq '.spec.retention'
  ```
  * Verify PVC is created for prometheus
  ```
  oc get pvc -n redhat-rhoam-observability
  ```
  