### PR TITLE
Changed Prometheus probes to be created for any RHOAM installation

### DIFF
--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -590,7 +590,7 @@ func (r *Reconciler) reconcileConsoleLink(ctx context.Context, serverClient k8sc
 }
 
 func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
-	if !integreatlyv1alpha1.IsRHOAMSingletenant(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
+	if !integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
 		cfg, err := r.ConfigManager.ReadMonitoring()
 		if err != nil {
 			return integreatlyv1alpha1.PhaseInProgress, nil
@@ -610,7 +610,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, client k8scli
 }
 
 func (r *Reconciler) reconcilePrometheusProbes(ctx context.Context, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
-	if integreatlyv1alpha1.IsRHOAMSingletenant(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
 		cfg, err := r.ConfigManager.ReadObservability()
 		if err != nil {
 			return integreatlyv1alpha1.PhaseInProgress, nil

--- a/pkg/products/rhssocommon/reconciler.go
+++ b/pkg/products/rhssocommon/reconciler.go
@@ -581,7 +581,7 @@ func (r *Reconciler) exportConfig(ctx context.Context, serverClient k8sclient.Cl
 }
 
 func (r *Reconciler) ReconcileBlackboxTargets(ctx context.Context, client k8sclient.Client, targetName string, url string, service string) (integreatlyv1alpha1.StatusPhase, error) {
-	if !integreatlyv1alpha1.IsRHOAMSingletenant(integreatlyv1alpha1.InstallationType(r.Installation.Spec.Type)) {
+	if !integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(r.Installation.Spec.Type)) {
 		cfg, err := r.ConfigManager.ReadMonitoring()
 		if err != nil {
 			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error reading monitoring config: %w", err)
@@ -599,7 +599,7 @@ func (r *Reconciler) ReconcileBlackboxTargets(ctx context.Context, client k8scli
 }
 
 func (r *Reconciler) ReconcilePrometheusProbes(ctx context.Context, client k8sclient.Client, targetName string, url string, service string) (integreatlyv1alpha1.StatusPhase, error) {
-	if integreatlyv1alpha1.IsRHOAMSingletenant(integreatlyv1alpha1.InstallationType(r.Installation.Spec.Type)) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(r.Installation.Spec.Type)) {
 		cfg, err := r.ConfigManager.ReadObservability()
 		if err != nil {
 			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error reading monitoring config: %w", err)

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1868,7 +1868,7 @@ func (r *Reconciler) reconcileServiceDiscovery(ctx context.Context, serverClient
 }
 
 func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
-	if !integreatlyv1alpha1.IsRHOAMSingletenant(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
+	if !integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
 		cfg, err := r.ConfigManager.ReadMonitoring()
 		if err != nil {
 			return integreatlyv1alpha1.PhaseInProgress, nil
@@ -1918,7 +1918,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, client k8scli
 }
 
 func (r *Reconciler) reconcilePrometheusProbes(ctx context.Context, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
-	if integreatlyv1alpha1.IsRHOAMSingletenant(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
 		cfg, err := r.ConfigManager.ReadObservability()
 		if err != nil {
 			return integreatlyv1alpha1.PhaseInProgress, nil


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-1878

# What
Changed the conditional that decides whether to create Prometheus probes or Blackbox targets so that probes are used for any RHOAM installation, not just single-tenant RHOAM installations. This change is required because now both the dev sandbox work and the onboarding to the obserability operator will be rolled out in the same release. Before we thought that the dev sandbox work would be released first but that has since changed.

# Verification steps
N/A
