### PR TITLE
add script to test the lenght of time it takes for monitoring to upgrade

### DIFF
--- a/scripts/monitoringupgradetest.sh
+++ b/scripts/monitoringupgradetest.sh
@@ -23,14 +23,17 @@ while true
 do
   oc get statefulsets prometheus-application-monitoring -n redhat-rhoam-middleware-monitoring-operator
   if [ "$?" == "1" ]; then
-    echo "Prometheus is removed"
-    oc get statefulsets alertmanager-application-monitoring -n redhat-rhoam-middleware-monitoring-operator
-    if [ "$?" == "1" ]; then
-      date +"%T"
-      echo "both AMO prometheus and alertmanager are now unavailable, moving on"
-      START=$(date +%s);
-      break
-    fi
+    echo "Prometheus is removed - moving on as either prometheus or alertmanager down means the stack has begun to uninstall"
+    date +"%T"
+    START=$(date +%s);
+    break
+  fi
+  oc get statefulsets alertmanager-application-monitoring -n redhat-rhoam-middleware-monitoring-operator
+  if [ "$?" == "1" ]; then
+    date +"%T"
+    echo "AlertManager is removed - moving on as either prometheus or alertmanager down means the stack has begun to uninstall"
+    START=$(date +%s);
+    break
   fi
   sleep 15
 done


### PR DESCRIPTION
# What
A script which allows to discover a closer time for how long the unavailability of the monitoring stack lasts during an upgrade.
I didn't write an automated test for this as it's very specific to this release.
My motivation for not using the `rhoam_version` metric is that this is for the whole upgrade. Once SSO and 3scale upgrades are included it's likely that the upgrade time will take significantly longer. in the case of the monitoring upgrade we need to know how long for each upgrade the monitoring stack will be unavailable.

# Verification steps
Install 1.12.0 using this index -> quay.io/laurafitzgerald/rhoam-index:1.12.0
Let the installation go complete aka there should be no entry for toVersion in the cr.
Run the script 
Then trigger an upgrade to "1.13.0" uisng index -> quay.io/laurafitzgerald/rhoam-index:v1.13.0-upgrade
The script should give you some output of checking the monitoring resourcess
Some error output is fine e.g. while waiting for the new stack resources to appear on the cluster
The final output should give a time of which the upgrade took.

