### PR TITLE
set observability config namespace in boostrap reconciler, if it's no…

### DIFF
--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -29,6 +29,8 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
+	"github.com/integr8ly/integreatly-operator/pkg/products/observability"
+
 
 	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -167,6 +169,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		observabilityConfig, err := r.ConfigManager.ReadObservability()
 		if err != nil {
 			return rhmiv1alpha1.PhaseFailed, err
+		}
+		ns := observability.GetDefaultNamespace(r.installation.Spec.NamespacePrefix)
+		if observabilityConfig.GetNamespace() == "" {
+			observabilityConfig.SetNamespace(ns)
+			err := r.ConfigManager.WriteConfig(observabilityConfig)
+			if err != nil {
+				return rhmiv1alpha1.PhaseFailed, err
+			}
 		}
 		phase, err = r.ReconcileNamespace(ctx, observabilityConfig.GetNamespace(), installation, serverClient, log)
 		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -64,7 +64,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 
 func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, logger l.Logger, productDeclaration *marketplace.ProductDeclaration) (*Reconciler, error) {
 
-	ns := installation.Spec.NamespacePrefix + defaultInstallationNamespace
+	ns := GetDefaultNamespace(installation.Spec.NamespacePrefix)
 	config, err := configManager.ReadObservability()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve observability config: %w", err)
@@ -559,4 +559,9 @@ func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClien
 		r.log.Infof("Operation result", l.Fields{"grafanaDashboard": grafanaDB.Name, "result": opRes})
 	}
 	return err
+}
+
+
+func GetDefaultNamespace(installationPrefix string) string {
+	return installationPrefix + defaultInstallationNamespace
 }

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -813,6 +813,14 @@ func TestReconciler_full_RHOAM_Reconcile(t *testing.T) {
 		},
 	}
 
+	// prometheus rule created by the SSO operator that is exported to the observability operator namespace
+	ssoAlert := &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keycloak",
+			Namespace: defaultNamespace,
+		},
+	}
+
 	cases := []struct {
 		Name                  string
 		ExpectError           bool
@@ -833,7 +841,7 @@ func TestReconciler_full_RHOAM_Reconcile(t *testing.T) {
 		{
 			Name:            "RHOAM - test successful reconcile",
 			ExpectedStatus:  integreatlyv1alpha1.PhaseCompleted,
-			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet),
+			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet, ssoAlert),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{


### PR DESCRIPTION
Fix

```
Bootstrap stage reconcile failed: failed to create observability operand
    namespace: could not retrieve namespace: . resource name may not be empty
```


# Issue link

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
On a fresh cluster install index quay.io/laurafitzgerald/rhoam-index:1.13.0-install
The error should not be present and the namespace is created in the bootstrap stage.