### PR TITLE
add observability stages to multitenant

### DIFF
--- a/controllers/rhmi/types.go
+++ b/controllers/rhmi/types.go
@@ -28,7 +28,7 @@ var (
 			{
 				Name: integreatlyv1alpha1.MonitoringStage,
 				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
-					integreatlyv1alpha1.ProductMonitoring:     {Name: integreatlyv1alpha1.ProductMonitoring},
+					integreatlyv1alpha1.ProductMonitoring:     {Name: integreatlyv1alpha1.ProductMonitoring, Uninstall: true},
 					integreatlyv1alpha1.ProductMonitoringSpec: {Name: integreatlyv1alpha1.ProductMonitoringSpec},
 				},
 			},
@@ -168,6 +168,9 @@ var (
 					integreatlyv1alpha1.ProductMonitoring:     {Name: integreatlyv1alpha1.ProductMonitoring},
 					integreatlyv1alpha1.ProductMonitoringSpec: {Name: integreatlyv1alpha1.ProductMonitoringSpec},
 				},
+			},
+			{
+				Name: integreatlyv1alpha1.UninstallBootstrap,
 			},
 		},
 	}


### PR DESCRIPTION
# What
Multitenant Managed API will also now take OBservability
Updating the type to have the correct stages.

# Verification steps
Verify the stages for install and uninstall match in the case of observability updates for both managedapi and multitenant managedapi stages

Verify that the IsRHOAMSingletenant function is no longer in use as this was only introduced to keep mutitentant on AMO.

